### PR TITLE
Ci test fix

### DIFF
--- a/pnc_cli/productmilestones.py
+++ b/pnc_cli/productmilestones.py
@@ -14,7 +14,8 @@ milestones_api = ProductmilestonesApi(utils.get_api_client())
 
 
 def product_version_exists(search_id):
-    return str(search_id) in [str(x.id) for x in productversions_api.get_all().content]
+    response = utils.checked_api_call(productversions_api, 'get_specific', id=search_id)
+    return response is not None
 
 
 def create_milestone_object(**kwargs):

--- a/pnc_cli/productreleases.py
+++ b/pnc_cli/productreleases.py
@@ -93,10 +93,10 @@ def get_release(id):
 
 def _product_release_exists(search_id):
     """
-    Check if a ProductVersion ID exists
+    Check if a Product release with the given id exists
     """
-    existing_release_ids = [str(x.id) for x in releases_api.get_all().content]
-    return str(search_id) in existing_release_ids
+    response = utils.checked_api_call(releases_api, 'get_specific', id=search_id)
+    return response is not None
 
 
 @arg("id", help="ID of the release to update.")

--- a/pnc_cli/products.py
+++ b/pnc_cli/products.py
@@ -24,8 +24,8 @@ def _product_exists(prod_id):
     :param prod_id: the ID to test for
     :return: True if found, False otherwise
     """
-    existing_ids = [str(x.id) for x in products_api.get_all().content]
-    return str(prod_id) in existing_ids
+    response = utils.checked_api_call(products_api, 'get_specific', id=prod_id)
+    return response is not None
 
 
 def get_product_id(prod_id, name):

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -95,20 +95,6 @@ def get_unique_version(product_id):
 
 
 @pytest.fixture(scope='module')
-def new_version(new_product):
-    version_number = testutils.gen_random_version()
-    existing = products.list_versions_for_product(id=new_product.id)
-    while existing is not None and version_number in [x.version for x in existing]:
-        version_number = testutils.gen_random_version()
-    version = productversions.create_product_version(
-        version=version_number,
-        product_id=1,
-        current_product_milestone_id=1
-    )
-    return version
-
-
-@pytest.fixture(scope='module')
 def new_milestone(new_version):
     starting = utils.unix_time_millis(datetime.datetime(2016, 1, 2, 12, 0, 0))
     ending = utils.unix_time_millis(datetime.datetime(2017, 1, 2, 12, 0, 0))


### PR DESCRIPTION
Fix failing CI tests.  The tests are currently failing due to the check for existing product version.  The server is only returning the first 50 results at a time, so when there are more product versions than 50, the test fails because it thinks the product version doesn't exist.