### PR TITLE
NCL-2024, NCL-2029, license_exists

### DIFF
--- a/pnc_cli/buildconfigurationsets.py
+++ b/pnc_cli/buildconfigurationsets.py
@@ -147,8 +147,8 @@ def delete_build_configuration_set(id=None, name=None):
         return response.content
 
 
-def _set_exists(id):
-    existing = sets_api.get_specific(id).content
+def _set_exists(set_id):
+    existing = utils.checked_api_call(sets_api, 'get_specific', id=set_id).content
     if not existing:
         return False
     return True

--- a/pnc_cli/licenses.py
+++ b/pnc_cli/licenses.py
@@ -35,7 +35,7 @@ def get_license_id(id, name):
 
 
 def _license_exists(license_id):
-    existing = licenses_api.get_specific(license_id).content
+    existing = utils.checked_api_call(licenses_api, 'get_specific', id=license_id)
     if not existing:
         return False
     return True

--- a/pnc_cli/products.py
+++ b/pnc_cli/products.py
@@ -69,6 +69,10 @@ def create_product(name, **kwargs):
     """
     Create a new Product
     """
+    if get_product_id_by_name(name):
+        logging.error("Product with the name {0} already exists.".format(name))
+        return
+
     product = _create_product_object(name=name, **kwargs)
     response = utils.checked_api_call(products_api, 'create_new', body=product)
     if response:
@@ -86,13 +90,17 @@ def update_product(product_id, **kwargs):
     """
     Update a Product with new information
     """
-    found_id = get_product_id(1, None)
+    found_id = get_product_id(product_id, None)
     if not found_id:
         return
 
     to_update = products_api.get_specific(id=found_id).content
 
     for key, value in iteritems(kwargs):
+        if key is 'name':
+             if get_product_id_by_name(value):
+                 logging.error("Product with the name {0} already exists.".format(value))
+                 return
         if value is not None:
             setattr(to_update, key, value)
 

--- a/test/unit/test_buildconfigurationsets.py
+++ b/test/unit/test_buildconfigurationsets.py
@@ -235,14 +235,14 @@ def test_delete_build_config_set_name_notexist(mock_delete, mock_get_set_id):
 @patch('pnc_cli.buildconfigurationsets.sets_api.get_specific', return_value=MagicMock(content=[MagicMock(id=1)]))
 def test_set_exists(mock_get_specific):
     result = buildconfigurationsets._set_exists(1)
-    mock_get_specific.assert_called_once_with(1)
+    mock_get_specific.assert_called_once_with(id=1)
     assert result
 
 
-@patch('pnc_cli.buildconfigurationsets.sets_api.get_all', return_value=MagicMock(content=[MagicMock(id=1)]))
+@patch('pnc_cli.buildconfigurationsets.sets_api.get_specific', return_value=MagicMock(content=[]))
 def test_set_exists_notexist(mock):
     result = buildconfigurationsets._set_exists(10)
-    mock.assert_called_once_with()
+    mock.assert_called_once_with(id=10)
     assert not result
 
 

--- a/test/unit/test_licenses.py
+++ b/test/unit/test_licenses.py
@@ -42,10 +42,10 @@ def test_get_license_id_none():
     assert not result
 
 
-@patch('pnc_cli.licenses.licenses_api.get_all', return_value=MagicMock(content=[MagicMock(id=1)]))
+@patch('pnc_cli.licenses.licenses_api.get_specific', return_value=MagicMock(content=[MagicMock(id=1)]))
 def test_license_exists(mock):
     result = licenses._license_exists(1)
-    mock.assert_called_once_with()
+    mock.assert_called_once_with(id=1)
     assert result
 
 @patch('pnc_cli.licenses.licenses_api.get_all', return_value=MagicMock(content=[MagicMock(full_name='testerino', id=1)]))


### PR DESCRIPTION
NCL-2024
- added checks for existing names of products before creating and updating
- warn user that name already exists

NCL-2029
- changed implementation for testing whether a build configuration set exist
- changed test_buildconfigurationsets accordingly

changed implementation of testing whether a license exists
- similar to NCL-2029 for buildconfigurationsets
- updated test_license_exists test case accordingly
