### PR TITLE
Use existing config fields and logging additions

### DIFF
--- a/pnc_cli/pnc.py
+++ b/pnc_cli/pnc.py
@@ -20,12 +20,15 @@ from pnc_cli import users
 from pnc_cli import archives
 import pnc_cli.user_config as uc
 from pnc_cli import makemead
-
-
-
-
+from pnc_cli import utils
+from pnc_cli.tools.utils import set_log_level
 
 parser = argh.ArghParser()
+
+parser.add_argument('--loglevel', choices=['debug-all','debug',
+    'info','warning','error', 'critical'],
+    help=("loglevel for pnc-cli"))
+
 parser.add_commands([uc.login,
                      products.create_product,
                      products.get_product,
@@ -116,11 +119,21 @@ parser.add_commands([uc.login,
                      buildconfigsetrecords.list_records_for_build_config_set,
                      users.get_logged_user,
                      makemead.make_mead,
-                     archives.generate_sources_zip])
+                     archives.generate_sources_zip,
+                     ])
 parser.autocomplete()
 
 
 def main():
+    args = parser.parse_args()
+
+    loglevel = args.loglevel
+    if loglevel is None:
+        loglevel = uc.user.loglevel
+
+    if loglevel is not None:
+        set_log_level(loglevel)
+
     parser.dispatch()
 
 

--- a/pnc_cli/user_config.py
+++ b/pnc_cli/user_config.py
@@ -13,7 +13,7 @@ import swagger_client
 import pnc_cli.utils as utils
 import keycloak_config as kc
 import pnc_server_config as psc
-
+from tools.utils import set_log_level
 
 
 # make sure that input behaves as expected
@@ -34,6 +34,7 @@ class UserConfig():
         self.token_time = 0
         self.username = self.load_username_from_config(config)
         self.password = self.load_password_from_config(config)
+        self.loglevel = self.load_loglevel_from_config(config)
         self.pnc_config = psc.PncServerConfig(config)
         self.keycloak_config = kc.KeycloakConfig(config)
         self.token = self.retrieve_keycloak_token()
@@ -96,6 +97,14 @@ class UserConfig():
             username = config.get('PNC', 'username')
             sys.stderr.write("Loaded username from pnc-cli.conf: {}\n".format(username))
             return username
+        except ConfigParser.NoOptionError:
+            return None
+
+    def load_loglevel_from_config(self, config):
+        try:
+            loglevel = config.get('PNC', 'loglevel')
+            sys.stderr.write("Loaded loglevel '{}' from pnc-cli.conf\n".format(loglevel))
+            return loglevel
         except ConfigParser.NoOptionError:
             return None
 
@@ -199,3 +208,5 @@ def login(username=None, password=None):
     user.token = user.retrieve_keycloak_token()
     user.apiclient = user.create_api_client()
     save()
+
+


### PR DESCRIPTION
I've made the following usability changes

- Allow a loglevel to be specified on the cli or in the pnc-cli.conf 
```pnc --loglevel critical make-mead -c foo.cfg```
- Use existing details in the .cfg for product name and version (but allow cli to overide) 
- Pulled in more recent version of ```config_utils.py``` from ip-tooling with extra metadata such as stakeholders and main deliverables