### PR TITLE
(Version-1.2.x) Regeneration of Swagger definition

### DIFF
--- a/pnc_cli/buildrecords.py
+++ b/pnc_cli/buildrecords.py
@@ -51,7 +51,7 @@ def list_records_for_project(id=None, name=None, page_size=200, sort="", q=""):
     List all BuildRecords for a given Project
     """
     project_id = common.set_id(projects_api, id, name)
-    response = utils.checked_api_call(records_api, 'get_all_for_project', project_id=project_id, page_size=page_size,
+    response = utils.checked_api_call(records_api, 'get_all_for_project_1', project_id=project_id, page_size=page_size,
                                       sort=sort, q=q)
     if response:
         return utils.format_json_list(response.content)

--- a/pnc_cli/swagger_client/__init__.py
+++ b/pnc_cli/swagger_client/__init__.py
@@ -69,7 +69,6 @@ from .models.repository_configuration import RepositoryConfiguration
 from .models.repository_configuration_page import RepositoryConfigurationPage
 from .models.repository_configuration_rest import RepositoryConfigurationRest
 from .models.repository_configuration_singleton import RepositoryConfigurationSingleton
-from .models.repository_creation_rest import RepositoryCreationRest
 from .models.repository_creation_url_auto_rest import RepositoryCreationUrlAutoRest
 from .models.singleton import Singleton
 from .models.ssh_credentials import SshCredentials

--- a/pnc_cli/swagger_client/apis/bpm_api.py
+++ b/pnc_cli/swagger_client/apis/bpm_api.py
@@ -274,84 +274,6 @@ class BpmApi(object):
                                             body=body_params,
                                             post_params=form_params,
                                             files=files,
-                                            response_type=None,
-                                            auth_settings=auth_settings,
-                                            callback=params.get('callback'))
-        return response
-
-    def start_r_creation_task(self, body, **kwargs):
-        """
-        Start Repository Creation (RC) task (which stores the RC) and store the BC on success task completion.
-        
-
-        This method makes a synchronous HTTP request by default. To make an
-        asynchronous HTTP request, please define a `callback` function
-        to be invoked when receiving the response.
-        >>> def callback_function(response):
-        >>>     pprint(response)
-        >>>
-        >>> thread = api.start_r_creation_task(body, callback=callback_function)
-
-        :param callback function: The callback function
-            for asynchronous request. (optional)
-        :param RepositoryCreationRest body: Task parameters. (required)
-        :return: None
-                 If the method is called asynchronously,
-                 returns the request thread.
-        """
-        # verify the required parameter 'body' is set
-        if body is None:
-            raise ValueError("Missing the required parameter `body` when calling `start_r_creation_task`")
-
-        all_params = ['body']
-        all_params.append('callback')
-
-        params = locals()
-        for key, val in iteritems(params['kwargs']):
-            if key not in all_params:
-                raise TypeError(
-                    "Got an unexpected keyword argument '%s'"
-                    " to method start_r_creation_task" % key
-                )
-            params[key] = val
-        del params['kwargs']
-
-        resource_path = '/bpm/tasks/start-repository-configuration-creation'.replace('{format}', 'json')
-        method = 'POST'
-
-        path_params = {}
-
-        query_params = {}
-
-        header_params = {}
-
-        form_params = {}
-        files = {}
-
-        body_params = None
-        if 'body' in params:
-            body_params = params['body']
-
-        # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
-            select_header_accept(['application/json'])
-        if not header_params['Accept']:
-            del header_params['Accept']
-
-        # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
-            select_header_content_type(['application/json'])
-
-        # Authentication setting
-        auth_settings = []
-
-        response = self.api_client.call_api(resource_path, method,
-                                            path_params,
-                                            query_params,
-                                            header_params,
-                                            body=body_params,
-                                            post_params=form_params,
-                                            files=files,
                                             response_type=int,
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'))
@@ -373,7 +295,7 @@ class BpmApi(object):
         :param callback function: The callback function
             for asynchronous request. (optional)
         :param RepositoryCreationUrlAutoRest body: Task parameters. (required)
-        :return: None
+        :return: int
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -430,7 +352,7 @@ class BpmApi(object):
                                             body=body_params,
                                             post_params=form_params,
                                             files=files,
-                                            response_type=int,
+                                            response_type='int',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'))
         return response

--- a/pnc_cli/swagger_client/apis/buildrecords_api.py
+++ b/pnc_cli/swagger_client/apis/buildrecords_api.py
@@ -219,7 +219,97 @@ class BuildrecordsApi(object):
                                             callback=params.get('callback'))
         return response
 
-    def get_all_for_project(self, project_id, **kwargs):
+    def get_all_for_project(self, name, **kwargs):
+        """
+        Gets the Build Records produced from the BuildConfiguration by name.
+        
+
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please define a `callback` function
+        to be invoked when receiving the response.
+        >>> def callback_function(response):
+        >>>     pprint(response)
+        >>>
+        >>> thread = api.get_all_for_project(name, callback=callback_function)
+
+        :param callback function: The callback function
+            for asynchronous request. (optional)
+        :param str name: BuildConfiguration name (required)
+        :param int page_index: Page index
+        :param int page_size: Pagination size
+        :param str sort: Sorting RSQL
+        :param str q: RSQL query
+        :return: BuildRecordPage
+                 If the method is called asynchronously,
+                 returns the request thread.
+        """
+        # verify the required parameter 'name' is set
+        if name is None:
+            raise ValueError("Missing the required parameter `name` when calling `get_all_for_project`")
+
+        all_params = ['name', 'page_index', 'page_size', 'sort', 'q']
+        all_params.append('callback')
+
+        params = locals()
+        for key, val in iteritems(params['kwargs']):
+            if key not in all_params:
+                raise TypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_all_for_project" % key
+                )
+            params[key] = val
+        del params['kwargs']
+
+        resource_path = '/build-records/build-configuration-or-project-name/{name}'.replace('{format}', 'json')
+        method = 'GET'
+
+        path_params = {}
+        if 'name' in params:
+            path_params['name'] = params['name']
+
+        query_params = {}
+        if 'page_index' in params:
+            query_params['pageIndex'] = params['page_index']
+        if 'page_size' in params:
+            query_params['pageSize'] = params['page_size']
+        if 'sort' in params:
+            query_params['sort'] = params['sort']
+        if 'q' in params:
+            query_params['q'] = params['q']
+
+        header_params = {}
+
+        form_params = {}
+        files = {}
+
+        body_params = None
+
+        # HTTP header `Accept`
+        header_params['Accept'] = self.api_client.\
+            select_header_accept(['application/json'])
+        if not header_params['Accept']:
+            del header_params['Accept']
+
+        # HTTP header `Content-Type`
+        header_params['Content-Type'] = self.api_client.\
+            select_header_content_type(['application/json'])
+
+        # Authentication setting
+        auth_settings = []
+
+        response = self.api_client.call_api(resource_path, method,
+                                            path_params,
+                                            query_params,
+                                            header_params,
+                                            body=body_params,
+                                            post_params=form_params,
+                                            files=files,
+                                            response_type='BuildRecordPage',
+                                            auth_settings=auth_settings,
+                                            callback=params.get('callback'))
+        return response
+
+    def get_all_for_project_1(self, project_id, **kwargs):
         """
         Gets the Build Records linked to a specific Project
         
@@ -230,7 +320,7 @@ class BuildrecordsApi(object):
         >>> def callback_function(response):
         >>>     pprint(response)
         >>>
-        >>> thread = api.get_all_for_project(project_id, callback=callback_function)
+        >>> thread = api.get_all_for_project_1(project_id, callback=callback_function)
 
         :param callback function: The callback function
             for asynchronous request. (optional)
@@ -245,7 +335,7 @@ class BuildrecordsApi(object):
         """
         # verify the required parameter 'project_id' is set
         if project_id is None:
-            raise ValueError("Missing the required parameter `project_id` when calling `get_all_for_project`")
+            raise ValueError("Missing the required parameter `project_id` when calling `get_all_for_project_1`")
 
         all_params = ['project_id', 'page_index', 'page_size', 'sort', 'q']
         all_params.append('callback')
@@ -255,7 +345,7 @@ class BuildrecordsApi(object):
             if key not in all_params:
                 raise TypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method get_all_for_project" % key
+                    " to method get_all_for_project_1" % key
                 )
             params[key] = val
         del params['kwargs']

--- a/pnc_cli/swagger_client/apis/builds_api.py
+++ b/pnc_cli/swagger_client/apis/builds_api.py
@@ -142,12 +142,14 @@ class BuildsApi(object):
         :param int page_size: Pagination size
         :param str sort: Sorting RSQL
         :param str q: RSQL Query
+        :param str or_find_by_build_configuration_name: Find by BuildConfigurationName (query is combined with other criteria using OR.).
+        :param str and_find_by_build_configuration_name: Find by BuildConfigurationName (query is combined with other criteria using AND.).
         :return: BuildRecordPage
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['page_index', 'page_size', 'sort', 'q']
+        all_params = ['page_index', 'page_size', 'sort', 'q', 'or_find_by_build_configuration_name', 'and_find_by_build_configuration_name']
         all_params.append('callback')
 
         params = locals()
@@ -174,6 +176,10 @@ class BuildsApi(object):
             query_params['sort'] = params['sort']
         if 'q' in params:
             query_params['q'] = params['q']
+        if 'or_find_by_build_configuration_name' in params:
+            query_params['orFindByBuildConfigurationName'] = params['or_find_by_build_configuration_name']
+        if 'and_find_by_build_configuration_name' in params:
+            query_params['andFindByBuildConfigurationName'] = params['and_find_by_build_configuration_name']
 
         header_params = {}
 

--- a/pnc_cli/swagger_client/apis/productmilestones_api.py
+++ b/pnc_cli/swagger_client/apis/productmilestones_api.py
@@ -734,7 +734,7 @@ class ProductmilestonesApi(object):
         :param int page_size: Pagination size
         :param str sort: Sorting RSQL
         :param str q: RSQL Query
-        :return: ProductMilestoneSingleton
+        :return: BuildRecordPage
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -799,7 +799,7 @@ class ProductmilestonesApi(object):
                                             body=body_params,
                                             post_params=form_params,
                                             files=files,
-                                            response_type='ProductMilestoneSingleton',
+                                            response_type='BuildRecordPage',
                                             auth_settings=auth_settings,
                                             callback=params.get('callback'))
         return response

--- a/pnc_cli/swagger_client/models/__init__.py
+++ b/pnc_cli/swagger_client/models/__init__.py
@@ -69,7 +69,6 @@ from .repository_configuration import RepositoryConfiguration
 from .repository_configuration_page import RepositoryConfigurationPage
 from .repository_configuration_rest import RepositoryConfigurationRest
 from .repository_configuration_singleton import RepositoryConfigurationSingleton
-from .repository_creation_rest import RepositoryCreationRest
 from .repository_creation_url_auto_rest import RepositoryCreationUrlAutoRest
 from .singleton import Singleton
 from .ssh_credentials import SshCredentials

--- a/pnc_cli/swagger_client/models/build_configuration.py
+++ b/pnc_cli/swagger_client/models/build_configuration.py
@@ -47,7 +47,6 @@ class BuildConfiguration(object):
             'product_version': 'ProductVersion',
             'project': 'Project',
             'build_environment': 'BuildEnvironment',
-            'build_records': 'list[BuildRecord]',
             'build_configuration_sets': 'list[BuildConfigurationSet]',
             'creation_time': 'datetime',
             'last_modification_time': 'datetime',
@@ -57,9 +56,8 @@ class BuildConfiguration(object):
             'all_dependencies': 'list[BuildConfiguration]',
             'indirect_dependencies': 'list[BuildConfiguration]',
             'archived': 'bool',
-            'current_product_milestone': 'ProductMilestone',
-            'latest_succesful_build_record': 'BuildRecord',
-            'field_handler': 'FieldHandler'
+            'field_handler': 'FieldHandler',
+            'current_product_milestone': 'ProductMilestone'
         }
 
         self.attribute_map = {
@@ -72,7 +70,6 @@ class BuildConfiguration(object):
             'product_version': 'productVersion',
             'project': 'project',
             'build_environment': 'buildEnvironment',
-            'build_records': 'buildRecords',
             'build_configuration_sets': 'buildConfigurationSets',
             'creation_time': 'creationTime',
             'last_modification_time': 'lastModificationTime',
@@ -82,9 +79,8 @@ class BuildConfiguration(object):
             'all_dependencies': 'allDependencies',
             'indirect_dependencies': 'indirectDependencies',
             'archived': 'archived',
-            'current_product_milestone': 'currentProductMilestone',
-            'latest_succesful_build_record': 'latestSuccesfulBuildRecord',
-            'field_handler': 'fieldHandler'
+            'field_handler': 'fieldHandler',
+            'current_product_milestone': 'currentProductMilestone'
         }
 
         self._id = None
@@ -96,7 +92,6 @@ class BuildConfiguration(object):
         self._product_version = None
         self._project = None
         self._build_environment = None
-        self._build_records = None
         self._build_configuration_sets = None
         self._creation_time = None
         self._last_modification_time = None
@@ -106,9 +101,8 @@ class BuildConfiguration(object):
         self._all_dependencies = None
         self._indirect_dependencies = None
         self._archived = None
-        self._current_product_milestone = None
-        self._latest_succesful_build_record = None
         self._field_handler = None
+        self._current_product_milestone = None
 
     @property
     def id(self):
@@ -309,28 +303,6 @@ class BuildConfiguration(object):
         self._build_environment = build_environment
 
     @property
-    def build_records(self):
-        """
-        Gets the build_records of this BuildConfiguration.
-
-
-        :return: The build_records of this BuildConfiguration.
-        :rtype: list[BuildRecord]
-        """
-        return self._build_records
-
-    @build_records.setter
-    def build_records(self, build_records):
-        """
-        Sets the build_records of this BuildConfiguration.
-
-
-        :param build_records: The build_records of this BuildConfiguration.
-        :type: list[BuildRecord]
-        """
-        self._build_records = build_records
-
-    @property
     def build_configuration_sets(self):
         """
         Gets the build_configuration_sets of this BuildConfiguration.
@@ -529,50 +501,6 @@ class BuildConfiguration(object):
         self._archived = archived
 
     @property
-    def current_product_milestone(self):
-        """
-        Gets the current_product_milestone of this BuildConfiguration.
-
-
-        :return: The current_product_milestone of this BuildConfiguration.
-        :rtype: ProductMilestone
-        """
-        return self._current_product_milestone
-
-    @current_product_milestone.setter
-    def current_product_milestone(self, current_product_milestone):
-        """
-        Sets the current_product_milestone of this BuildConfiguration.
-
-
-        :param current_product_milestone: The current_product_milestone of this BuildConfiguration.
-        :type: ProductMilestone
-        """
-        self._current_product_milestone = current_product_milestone
-
-    @property
-    def latest_succesful_build_record(self):
-        """
-        Gets the latest_succesful_build_record of this BuildConfiguration.
-
-
-        :return: The latest_succesful_build_record of this BuildConfiguration.
-        :rtype: BuildRecord
-        """
-        return self._latest_succesful_build_record
-
-    @latest_succesful_build_record.setter
-    def latest_succesful_build_record(self, latest_succesful_build_record):
-        """
-        Sets the latest_succesful_build_record of this BuildConfiguration.
-
-
-        :param latest_succesful_build_record: The latest_succesful_build_record of this BuildConfiguration.
-        :type: BuildRecord
-        """
-        self._latest_succesful_build_record = latest_succesful_build_record
-
-    @property
     def field_handler(self):
         """
         Gets the field_handler of this BuildConfiguration.
@@ -593,6 +521,28 @@ class BuildConfiguration(object):
         :type: FieldHandler
         """
         self._field_handler = field_handler
+
+    @property
+    def current_product_milestone(self):
+        """
+        Gets the current_product_milestone of this BuildConfiguration.
+
+
+        :return: The current_product_milestone of this BuildConfiguration.
+        :rtype: ProductMilestone
+        """
+        return self._current_product_milestone
+
+    @current_product_milestone.setter
+    def current_product_milestone(self, current_product_milestone):
+        """
+        Sets the current_product_milestone of this BuildConfiguration.
+
+
+        :param current_product_milestone: The current_product_milestone of this BuildConfiguration.
+        :type: ProductMilestone
+        """
+        self._current_product_milestone = current_product_milestone
 
     def to_dict(self):
         """

--- a/pnc_cli/swagger_client/models/build_configuration_audited.py
+++ b/pnc_cli/swagger_client/models/build_configuration_audited.py
@@ -38,7 +38,7 @@ class BuildConfigurationAudited(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'id': 'IdRev',
+            'id': 'int',
             'rev': 'int',
             'id_rev': 'IdRev',
             'name': 'str',
@@ -49,6 +49,7 @@ class BuildConfigurationAudited(object):
             'project': 'Project',
             'build_environment': 'BuildEnvironment',
             'build_records': 'list[BuildRecord]',
+            'build_configuration': 'BuildConfiguration',
             'generic_parameters': 'dict(str, str)',
             'field_handler': 'FieldHandler'
         }
@@ -65,6 +66,7 @@ class BuildConfigurationAudited(object):
             'project': 'project',
             'build_environment': 'buildEnvironment',
             'build_records': 'buildRecords',
+            'build_configuration': 'buildConfiguration',
             'generic_parameters': 'genericParameters',
             'field_handler': 'fieldHandler'
         }
@@ -80,6 +82,7 @@ class BuildConfigurationAudited(object):
         self._project = None
         self._build_environment = None
         self._build_records = None
+        self._build_configuration = None
         self._generic_parameters = None
         self._field_handler = None
 
@@ -90,7 +93,7 @@ class BuildConfigurationAudited(object):
 
 
         :return: The id of this BuildConfigurationAudited.
-        :rtype: IdRev
+        :rtype: int
         """
         return self._id
 
@@ -101,7 +104,7 @@ class BuildConfigurationAudited(object):
 
 
         :param id: The id of this BuildConfigurationAudited.
-        :type: IdRev
+        :type: int
         """
         self._id = id
 
@@ -324,6 +327,28 @@ class BuildConfigurationAudited(object):
         :type: list[BuildRecord]
         """
         self._build_records = build_records
+
+    @property
+    def build_configuration(self):
+        """
+        Gets the build_configuration of this BuildConfigurationAudited.
+
+
+        :return: The build_configuration of this BuildConfigurationAudited.
+        :rtype: BuildConfiguration
+        """
+        return self._build_configuration
+
+    @build_configuration.setter
+    def build_configuration(self, build_configuration):
+        """
+        Sets the build_configuration of this BuildConfigurationAudited.
+
+
+        :param build_configuration: The build_configuration of this BuildConfigurationAudited.
+        :type: BuildConfiguration
+        """
+        self._build_configuration = build_configuration
 
     @property
     def generic_parameters(self):

--- a/pnc_cli/swagger_client/models/build_record.py
+++ b/pnc_cli/swagger_client/models/build_record.py
@@ -39,8 +39,9 @@ class BuildRecord(object):
         """
         self.swagger_types = {
             'id': 'int',
-            'latest_build_configuration': 'BuildConfiguration',
             'build_configuration_audited': 'BuildConfigurationAudited',
+            'build_configuration_id': 'int',
+            'build_configuration_rev': 'int',
             'build_content_id': 'str',
             'submit_time': 'datetime',
             'start_time': 'datetime',
@@ -61,13 +62,15 @@ class BuildRecord(object):
             'build_config_set_record': 'BuildConfigSetRecord',
             'attributes': 'dict(str, str)',
             'repour_log': 'str',
-            'field_handler': 'FieldHandler'
+            'field_handler': 'FieldHandler',
+            'build_configuration_audited_id_rev': 'IdRev'
         }
 
         self.attribute_map = {
             'id': 'id',
-            'latest_build_configuration': 'latestBuildConfiguration',
             'build_configuration_audited': 'buildConfigurationAudited',
+            'build_configuration_id': 'buildConfigurationId',
+            'build_configuration_rev': 'buildConfigurationRev',
             'build_content_id': 'buildContentId',
             'submit_time': 'submitTime',
             'start_time': 'startTime',
@@ -88,12 +91,14 @@ class BuildRecord(object):
             'build_config_set_record': 'buildConfigSetRecord',
             'attributes': 'attributes',
             'repour_log': 'repourLog',
-            'field_handler': 'fieldHandler'
+            'field_handler': 'fieldHandler',
+            'build_configuration_audited_id_rev': 'buildConfigurationAuditedIdRev'
         }
 
         self._id = None
-        self._latest_build_configuration = None
         self._build_configuration_audited = None
+        self._build_configuration_id = None
+        self._build_configuration_rev = None
         self._build_content_id = None
         self._submit_time = None
         self._start_time = None
@@ -115,6 +120,7 @@ class BuildRecord(object):
         self._attributes = None
         self._repour_log = None
         self._field_handler = None
+        self._build_configuration_audited_id_rev = None
 
     @property
     def id(self):
@@ -139,28 +145,6 @@ class BuildRecord(object):
         self._id = id
 
     @property
-    def latest_build_configuration(self):
-        """
-        Gets the latest_build_configuration of this BuildRecord.
-
-
-        :return: The latest_build_configuration of this BuildRecord.
-        :rtype: BuildConfiguration
-        """
-        return self._latest_build_configuration
-
-    @latest_build_configuration.setter
-    def latest_build_configuration(self, latest_build_configuration):
-        """
-        Sets the latest_build_configuration of this BuildRecord.
-
-
-        :param latest_build_configuration: The latest_build_configuration of this BuildRecord.
-        :type: BuildConfiguration
-        """
-        self._latest_build_configuration = latest_build_configuration
-
-    @property
     def build_configuration_audited(self):
         """
         Gets the build_configuration_audited of this BuildRecord.
@@ -181,6 +165,50 @@ class BuildRecord(object):
         :type: BuildConfigurationAudited
         """
         self._build_configuration_audited = build_configuration_audited
+
+    @property
+    def build_configuration_id(self):
+        """
+        Gets the build_configuration_id of this BuildRecord.
+
+
+        :return: The build_configuration_id of this BuildRecord.
+        :rtype: int
+        """
+        return self._build_configuration_id
+
+    @build_configuration_id.setter
+    def build_configuration_id(self, build_configuration_id):
+        """
+        Sets the build_configuration_id of this BuildRecord.
+
+
+        :param build_configuration_id: The build_configuration_id of this BuildRecord.
+        :type: int
+        """
+        self._build_configuration_id = build_configuration_id
+
+    @property
+    def build_configuration_rev(self):
+        """
+        Gets the build_configuration_rev of this BuildRecord.
+
+
+        :return: The build_configuration_rev of this BuildRecord.
+        :rtype: int
+        """
+        return self._build_configuration_rev
+
+    @build_configuration_rev.setter
+    def build_configuration_rev(self, build_configuration_rev):
+        """
+        Sets the build_configuration_rev of this BuildRecord.
+
+
+        :param build_configuration_rev: The build_configuration_rev of this BuildRecord.
+        :type: int
+        """
+        self._build_configuration_rev = build_configuration_rev
 
     @property
     def build_content_id(self):
@@ -649,6 +677,28 @@ class BuildRecord(object):
         :type: FieldHandler
         """
         self._field_handler = field_handler
+
+    @property
+    def build_configuration_audited_id_rev(self):
+        """
+        Gets the build_configuration_audited_id_rev of this BuildRecord.
+
+
+        :return: The build_configuration_audited_id_rev of this BuildRecord.
+        :rtype: IdRev
+        """
+        return self._build_configuration_audited_id_rev
+
+    @build_configuration_audited_id_rev.setter
+    def build_configuration_audited_id_rev(self, build_configuration_audited_id_rev):
+        """
+        Sets the build_configuration_audited_id_rev of this BuildRecord.
+
+
+        :param build_configuration_audited_id_rev: The build_configuration_audited_id_rev of this BuildRecord.
+        :type: IdRev
+        """
+        self._build_configuration_audited_id_rev = build_configuration_audited_id_rev
 
     def to_dict(self):
         """


### PR DESCRIPTION
The regeneration is generated as part of NCL-3409.

Below is a list of files that changed, and the investigation on whether
this affects pnc-cli:

- bpm_api.py: removed `start_r_creation_task` method: Not used
- build_records_api.py: `get_all_for_project` renamed to `get_all_for_project_1`
  * buildrecords.py edited with rename

- builds_api.py: nothing really changed
- productmilestones_api.py: `get_distributed_builds` return obj altered,
  only `list-distributed-builds` sub-command affected

- build_configuration.py
  - removed `build_records` method/property: Not used
  - removed `latest_successful_build_record` method/property: Not used

- build_configuration_audited.py
  - Methods added, pnc-cli not affected

- build_records.py:
  - removed `latest_build_configuration` method: Not used
  - latest_successful_build_record key: not used