### PR TITLE
[1.4.x] Add support for buildType in configuration

### DIFF
--- a/pnc_cli/buildconfigurations.py
+++ b/pnc_cli/buildconfigurations.py
@@ -204,6 +204,7 @@ def delete_build_configuration(id=None, name=None):
 @arg("-pvi", "--product-version-id", help="Associated ProductVersion ID.")
 @arg("-dids", "--dependency-ids", type=int, nargs="+",
      help="List of BuildConfiguration IDs that are dependencies of this BuildConfiguration.")
+@arg("--build_type", type=str, default='MVN', choices=['MVN', 'NPM'])
 # @arg("-bcsid", "--")
 def create_build_configuration(**kwargs):
     data = create_build_configuration_raw(**kwargs)

--- a/pnc_cli/makemead.py
+++ b/pnc_cli/makemead.py
@@ -31,7 +31,7 @@ from pnc_cli.tools.config_utils import ConfigReader
  Example: --look-up-only jdg-infinispan
  Will look up jdg-infinispan section and process a look up of BC by name (jdg-infinispan-${version_field}.
 """)
-@arg('--build-type', default='MVN', choices=['MVN', 'NPM'])
+@arg('--build_type', default='MVN', choices=['MVN', 'NPM'])
 def make_mead(config=None, run_build=False, environment=1, sufix="", product_name=None, product_version=None,
               look_up_only="", build_type):
     """

--- a/pnc_cli/swagger_client/__init__.py
+++ b/pnc_cli/swagger_client/__init__.py
@@ -34,7 +34,6 @@ from .models.build_record_singleton import BuildRecordSingleton
 from .models.build_set_status_changed_event import BuildSetStatusChangedEvent
 from .models.build_status_changed_event_rest import BuildStatusChangedEventRest
 from .models.error_response_rest import ErrorResponseRest
-from .models.field_handler import FieldHandler
 from .models.id_rev import IdRev
 from .models.license_page import LicensePage
 from .models.license_rest import LicenseRest

--- a/pnc_cli/swagger_client/models/__init__.py
+++ b/pnc_cli/swagger_client/models/__init__.py
@@ -34,7 +34,6 @@ from .build_record_singleton import BuildRecordSingleton
 from .build_set_status_changed_event import BuildSetStatusChangedEvent
 from .build_status_changed_event_rest import BuildStatusChangedEventRest
 from .error_response_rest import ErrorResponseRest
-from .field_handler import FieldHandler
 from .id_rev import IdRev
 from .license_page import LicensePage
 from .license_rest import LicenseRest

--- a/pnc_cli/swagger_client/models/build_configuration_rest.py
+++ b/pnc_cli/swagger_client/models/build_configuration_rest.py
@@ -48,6 +48,7 @@ class BuildConfigurationRest(object):
             'last_modification_time': 'datetime',
             'archived': 'bool',
             'project': 'ProjectRest',
+            'build_type': 'str',
             'environment': 'BuildEnvironmentRest',
             'dependency_ids': 'list[int]',
             'product_version_id': 'int',
@@ -66,6 +67,7 @@ class BuildConfigurationRest(object):
             'last_modification_time': 'lastModificationTime',
             'archived': 'archived',
             'project': 'project',
+            'build_type': 'buildType',
             'environment': 'environment',
             'dependency_ids': 'dependencyIds',
             'product_version_id': 'productVersionId',
@@ -83,6 +85,7 @@ class BuildConfigurationRest(object):
         self._last_modification_time = None
         self._archived = None
         self._project = None
+        self._build_type = None
         self._environment = None
         self._dependency_ids = None
         self._product_version_id = None
@@ -308,6 +311,34 @@ class BuildConfigurationRest(object):
         :type: ProjectRest
         """
         self._project = project
+
+    @property
+    def build_type(self):
+        """
+        Gets the build_type of this BuildConfigurationRest.
+
+
+        :return: The build_type of this BuildConfigurationRest.
+        :rtype: str
+        """
+        return self._build_type
+
+    @build_type.setter
+    def build_type(self, build_type):
+        """
+        Sets the build_type of this BuildConfigurationRest.
+
+
+        :param build_type: The build_type of this BuildConfigurationRest.
+        :type: str
+        """
+        allowed_values = ["MVN", "NPM"]
+        if build_type not in allowed_values:
+            raise ValueError(
+                "Invalid value for `build_type`, must be one of {0}"
+                .format(allowed_values)
+            )
+        self._build_type = build_type
 
     @property
     def environment(self):

--- a/pnc_cli/swagger_client/models/build_set_status_changed_event.py
+++ b/pnc_cli/swagger_client/models/build_set_status_changed_event.py
@@ -38,60 +38,35 @@ class BuildSetStatusChangedEvent(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'description': 'str',
             'user_id': 'int',
-            'new_status': 'str',
             'old_status': 'str',
             'build_set_task_id': 'int',
             'build_set_configuration_name': 'str',
             'build_set_start_time': 'datetime',
             'build_set_end_time': 'datetime',
-            'build_set_configuration_id': 'int'
+            'build_set_configuration_id': 'int',
+            'new_status': 'str'
         }
 
         self.attribute_map = {
-            'description': 'description',
             'user_id': 'userId',
-            'new_status': 'newStatus',
             'old_status': 'oldStatus',
             'build_set_task_id': 'buildSetTaskId',
             'build_set_configuration_name': 'buildSetConfigurationName',
             'build_set_start_time': 'buildSetStartTime',
             'build_set_end_time': 'buildSetEndTime',
-            'build_set_configuration_id': 'buildSetConfigurationId'
+            'build_set_configuration_id': 'buildSetConfigurationId',
+            'new_status': 'newStatus'
         }
 
-        self._description = None
         self._user_id = None
-        self._new_status = None
         self._old_status = None
         self._build_set_task_id = None
         self._build_set_configuration_name = None
         self._build_set_start_time = None
         self._build_set_end_time = None
         self._build_set_configuration_id = None
-
-    @property
-    def description(self):
-        """
-        Gets the description of this BuildSetStatusChangedEvent.
-
-
-        :return: The description of this BuildSetStatusChangedEvent.
-        :rtype: str
-        """
-        return self._description
-
-    @description.setter
-    def description(self, description):
-        """
-        Sets the description of this BuildSetStatusChangedEvent.
-
-
-        :param description: The description of this BuildSetStatusChangedEvent.
-        :type: str
-        """
-        self._description = description
+        self._new_status = None
 
     @property
     def user_id(self):
@@ -114,34 +89,6 @@ class BuildSetStatusChangedEvent(object):
         :type: int
         """
         self._user_id = user_id
-
-    @property
-    def new_status(self):
-        """
-        Gets the new_status of this BuildSetStatusChangedEvent.
-
-
-        :return: The new_status of this BuildSetStatusChangedEvent.
-        :rtype: str
-        """
-        return self._new_status
-
-    @new_status.setter
-    def new_status(self, new_status):
-        """
-        Sets the new_status of this BuildSetStatusChangedEvent.
-
-
-        :param new_status: The new_status of this BuildSetStatusChangedEvent.
-        :type: str
-        """
-        allowed_values = ["NEW", "DONE", "REJECTED"]
-        if new_status not in allowed_values:
-            raise ValueError(
-                "Invalid value for `new_status`, must be one of {0}"
-                .format(allowed_values)
-            )
-        self._new_status = new_status
 
     @property
     def old_status(self):
@@ -280,6 +227,34 @@ class BuildSetStatusChangedEvent(object):
         :type: int
         """
         self._build_set_configuration_id = build_set_configuration_id
+
+    @property
+    def new_status(self):
+        """
+        Gets the new_status of this BuildSetStatusChangedEvent.
+
+
+        :return: The new_status of this BuildSetStatusChangedEvent.
+        :rtype: str
+        """
+        return self._new_status
+
+    @new_status.setter
+    def new_status(self, new_status):
+        """
+        Sets the new_status of this BuildSetStatusChangedEvent.
+
+
+        :param new_status: The new_status of this BuildSetStatusChangedEvent.
+        :type: str
+        """
+        allowed_values = ["NEW", "DONE", "REJECTED"]
+        if new_status not in allowed_values:
+            raise ValueError(
+                "Invalid value for `new_status`, must be one of {0}"
+                .format(allowed_values)
+            )
+        self._new_status = new_status
 
     def to_dict(self):
         """

--- a/pnc_cli/swagger_client/models/id_rev.py
+++ b/pnc_cli/swagger_client/models/id_rev.py
@@ -39,19 +39,16 @@ class IdRev(object):
         """
         self.swagger_types = {
             'id': 'int',
-            'rev': 'int',
-            'field_handler': 'FieldHandler'
+            'rev': 'int'
         }
 
         self.attribute_map = {
             'id': 'id',
-            'rev': 'rev',
-            'field_handler': 'fieldHandler'
+            'rev': 'rev'
         }
 
         self._id = None
         self._rev = None
-        self._field_handler = None
 
     @property
     def id(self):
@@ -96,28 +93,6 @@ class IdRev(object):
         :type: int
         """
         self._rev = rev
-
-    @property
-    def field_handler(self):
-        """
-        Gets the field_handler of this IdRev.
-
-
-        :return: The field_handler of this IdRev.
-        :rtype: FieldHandler
-        """
-        return self._field_handler
-
-    @field_handler.setter
-    def field_handler(self, field_handler):
-        """
-        Sets the field_handler of this IdRev.
-
-
-        :param field_handler: The field_handler of this IdRev.
-        :type: FieldHandler
-        """
-        self._field_handler = field_handler
 
     def to_dict(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
 setup(
     name='pnc-cli',
     packages=find_packages(exclude=['test*']),
-    version='1.3.0',
+    version='1.4.0',
     description='CLI for the Project Newcastle build system',
     author = 'Tom Hauser',
     author_email = 'thauser@redhat.com',


### PR DESCRIPTION
For PNC 1.4, we have added a mandatory field for build configuration
named 'buildType', which specifies whether a build is a maven or npm
build (for now, more options to be added later).

To support this new field, the option '--build_type' has been added to
create a new build configuration (for cli 'create-build-configuration')
and for 'make-mead'.

The default for this option is 'MVN'.

Still on the TODO list: Investigate how this new type affect the Maitai
process and if we need to do adjustments to the bpmconfiguration
creation on make-mead.