### PR TITLE
Fix calling wrong function

### DIFF
--- a/pnc_cli/makemead.py
+++ b/pnc_cli/makemead.py
@@ -139,7 +139,7 @@ def make_mead_impl(config, run_build, environment, sufix, product_name, product_
                 build_config = create_build_configuration(env, bc_set, product_version_id, art_params, scm_repo_url,
                                                           scm_revision, artifact_name, project)
             else:
-                build_config = update_build_configuration_raw(env, product_version_id, art_params, scm_repo_url,
+                build_config = update_build_configuration(env, product_version_id, art_params, scm_repo_url,
                                                               scm_revision, artifact_name, project)
 
         # Make sure existing configs are added the group


### PR DESCRIPTION
Error
> NameError: global name 'update_build_configuration_raw' is not defined`
when updating build configuration for existing projects.
From the source code, `update_build_configuration_raw()` should be used by `update_build_configuration` which is a wrapper for the former.