### PR TITLE
Fix three bugs in the `pnc make-mead` command

### DIFF
--- a/pnc_cli/buildconfigurations.py
+++ b/pnc_cli/buildconfigurations.py
@@ -171,7 +171,7 @@ def update_build_configuration_raw(id, **kwargs):
         update_env = {'environment': env_rest}
         kwargs.update(update_env)
 
-    if kwargs.get("generic_parameters"):
+    if isinstance(kwargs.get("generic_parameters"), str):
         kwargs["generic_parameters"] = ast.literal_eval(kwargs.get("generic_parameters"))
 
     for key, value in kwargs.items():

--- a/pnc_cli/makemead.py
+++ b/pnc_cli/makemead.py
@@ -140,7 +140,7 @@ def make_mead_impl(config, run_build, environment, sufix, product_name, product_
                                                           scm_revision, artifact_name, project)
             else:
                 build_config = update_build_configuration(env, product_version_id, art_params, scm_repo_url,
-                                                              scm_revision, artifact_name, project)
+                                                          scm_revision, artifact_name, project)
 
         # Make sure existing configs are added the group
         if build_config is not None and build_config.id not in bc_set.build_configuration_ids:
@@ -254,7 +254,7 @@ def update_build_configuration(environment, product_version_id, art_params, scm_
 
     scm_repo_url_no_git_ext = _remove_git_ext(scm_repo_url)
 
-    if _remove_git_ext(internal_url) != scm_repo_url_no_git_ext and _remove_git_ext(external_url) != scm_repo_url_no_git_ext:
+    if _remove_git_ext(internal_url) != scm_repo_url_no_git_ext and (external_url is not None and _remove_git_ext(external_url) != scm_repo_url_no_git_ext):
         logging.error("SCM URL of existing Build Configuration '%s' cannot be changed" % artifact_name)
         return None
 


### PR DESCRIPTION
I found some bugs while running the build of RH-SSO 7.2.2, which uses the `make-mead` subcommand.

- `pnc_cli/buildconfigurations.py` tries to AST parse a dict type sent to it by `pnc_cli/makemead.py`. I've added a type check to only parse strings.
- `pnc_cli/makemead.py` tries to call a non-existing function `update_build_configuration_raw`. I think an eariler commit accidentally changed this due to a similar name.
- `pnc_cli/makemead.py` also attempts to parse a None-type external_url returned from the API. I've added a type check so it handles this gracefully.