### PR TITLE
Write ApiExceptions to stderr instead of stdout

### DIFF
--- a/pnc_cli/utils.py
+++ b/pnc_cli/utils.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     import ConfigParser as configparser
 import re
+import sys
 import errno
 import os
 import datetime
@@ -46,7 +47,8 @@ def checked_api_call(api, func, **kwargs):
     try:
         response = getattr(api, func)(**kwargs)
     except ApiException as e:
-        print(e)
+        sys.stderr.write(e)
+        sys.stderr.write("\n")
     else:
         return response
 


### PR DESCRIPTION
Currently, when there's an API error, the error is written to stdout. An Example:

    (409)
    Reason: Conflict
    HTTP response headers: HTTPHeaderDict({'Content-Length': '190', ...})
    HTTP response body: {"errorType":"ConflictedEntryException","errorMessage":"Build configuration with the same name already exists","details":{"conflictedRecordId":"720","conflictedEntity":"BuildConfiguration"}}

Normally the CLI would output valid json to stdout, and since this is not valid json:

1. jq, or any other tool connected to the output of the cli to fail with a parse error
2. the error message is lost, as it's consumed by jq before being discarded as non-json

It also goes against the output conventions for CLI tools.

To fix this, I've changed checked_api_call to use sys.stderr.write instead of print.