### PR TITLE
Load from config if cached user file corrupted

### DIFF
--- a/pnc_cli/user_config.py
+++ b/pnc_cli/user_config.py
@@ -209,13 +209,18 @@ def get_user():
     global user
     if user is None:
         if os.path.exists(SAVED_USER):
-            user = pickle.load(open(SAVED_USER, "rb"))
-            if user.keycloak_config.client_mode in trueValues:
-                logging.info("Command performed using client authorization.\n")
-            else:
-                logging.info("Command performed with user: {}\n".format(user.username))
-            users_api = swagger_client.UsersApi(user.get_api_client())
-            utils.checked_api_call(users_api, 'get_logged_user') # inits the user if it doesn't exist in pnc's db already
+            try:
+                user = pickle.load(open(SAVED_USER, "rb"))
+                if user.keycloak_config.client_mode in trueValues:
+                    logging.info("Command performed using client authorization.\n")
+                else:
+                    logging.info("Command performed with user: {}\n".format(user.username))
+                users_api = swagger_client.UsersApi(user.get_api_client())
+                utils.checked_api_call(users_api, 'get_logged_user') # inits the user if it doesn't exist in pnc's db already
+            except ValueError:
+                os.remove(SAVED_USER)
+                logging.debug("Pickled save user corrupted, loading from config file instead")
+                user = UserConfig()
         else:
             user = UserConfig()
     return user


### PR DESCRIPTION
There's a particular scenario where the pickled user cannot be loaded,
producing this error:

```
➜  pnc-cli git:(version-1.3.x) ✗ pnc get-repository-configuration '10'
Traceback (most recent call last):
  File "/usr/bin/pnc", line 11, in <module>
    load_entry_point('pnc-cli==1.3.6', 'console_scripts', 'pnc')()
  File "build/bdist.linux-x86_64/egg/pnc_cli/pnc.py", line 137, in main
  File "/usr/lib/python2.7/site-packages/argh/helpers.py", line 55, in dispatch
    return dispatch(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/argh/dispatching.py", line 174, in dispatch
    for line in lines:
  File "/usr/lib/python2.7/site-packages/argh/dispatching.py", line 277, in _execute_command
    for line in result:
  File "/usr/lib/python2.7/site-packages/argh/dispatching.py", line 260, in _call
    result = function(*positional, **keywords)
  File "build/bdist.linux-x86_64/egg/pnc_cli/repositoryconfigurations.py", line 18, in get_repository_configuration
  File "build/bdist.linux-x86_64/egg/pnc_cli/pnc_api.py", line 138, in repositories
  File "build/bdist.linux-x86_64/egg/pnc_cli/pnc_api.py", line 48, in user
  File "build/bdist.linux-x86_64/egg/pnc_cli/user_config.py", line 176, in get_user
  File "/usr/lib64/python2.7/pickle.py", line 1384, in load
    return Unpickler(file).load()
  File "/usr/lib64/python2.7/pickle.py", line 864, in load
    dispatch[key](self)
  File "/usr/lib64/python2.7/pickle.py", line 1223, in load_build
    setstate(state)
  File "build/bdist.linux-x86_64/egg/pnc_cli/user_config.py", line 53, in __setstate__
ValueError: too many values to unpack
```

This might happen because the pickled file changed format or object
changed in between PNC versions. In those cases, we should delete the
pickle file and load from config instead to invalidate the
'cached/pickled' file/object.