### PR TITLE
fix anonymous usage

### DIFF
--- a/pnc_cli/utils.py
+++ b/pnc_cli/utils.py
@@ -102,7 +102,8 @@ def get_config():
         if e.errno != errno.EEXIST:
             raise
 
-    found = config.read(os.path.join(configfilename))
+    configFileName = os.path.join(configfilename)
+    found = config.read(configFileName)
 
     if not found:
         config.add_section('PNC')
@@ -113,11 +114,11 @@ def get_config():
         config.set('PNC', 'keycloakClientId', 'pncdirect')
         username = input('Username: ')
         config.set('PNC', 'username', username)
-        with open(os.path.join(configfilename), 'w') as configfile:
+        with open(configFileName, 'w') as configfile:
             config.write(configfile)
         logging.warning("New config file written to %s. Configure pncUrl and keycloakUrl values." % configfilename)
         exit(1)
-    return config
+    return (config, configFileName)
 
 
 def get_internal_repo_start(environment):


### PR DESCRIPTION
### Checklist:

* [ ] Have you added a note in the CHANGELOG.md for your change if user-facing?
not user facing
* [ ] Have you added unit tests for your change?
no

The issue was that in my case different ConfigParser library was used (from backports), so except ConfigParser.NoOptionError block was not triggered as the actual exception type was different.
I've fixed that using  configparser # see https://pypi.org/project/configparser/ which at the same moment is python 2.7/3.x compatible.
I've also changed a bit when and which error messages are written in case user is not logged in