### PR TITLE
Fix pnc get-revision-of-build-configuration

### DIFF
--- a/pnc_cli/buildconfigurations.py
+++ b/pnc_cli/buildconfigurations.py
@@ -497,7 +497,7 @@ def get_revision_of_build_configuration(revision_id, id=None, name=None):
     """
     data = get_revision_of_build_configuration_raw(revision_id, id, name)
     if data:
-        return utils.format_json_list(data)
+        return utils.format_json(data)
 
 def get_revision_of_build_configuration_raw(revision_id, id=None, name=None):
     found_id = common.set_id(pnc_api.build_configs, id, name)


### PR DESCRIPTION
Fix pnc get-revision-of-build-configuration failing due to not working unwrap of the REST response

### Checklist:

* [x] Have you added a note in the [Changelog](https://github.com/project-ncl/pnc-cli/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
