### PR TITLE
[NCL-5489] Save the sources tar.gz

### DIFF
--- a/pnc_cli/buildrecords.py
+++ b/pnc_cli/buildrecords.py
@@ -4,7 +4,6 @@ import pnc_cli.common as common
 import pnc_cli.cli_types as types
 import pnc_cli.utils as utils
 from pnc_cli.pnc_api import pnc_api
-from urllib import urlretrieve
 
 @arg("-p", "--page-size", help="Limit the amount of BuildRecords returned", type=int)
 @arg("--page-index", help="Select the index of page", type=int)
@@ -237,6 +236,9 @@ def download_scm_sources_for_record(id):
         return data
 
 def download_scm_sources_for_record_raw(id):
-    response = utils.checked_api_call(pnc_api.builds, 'download_scm_sources', id=id)
+    response = utils.checked_api_call(pnc_api.builds, 'download_scm_sources', id=id, _preload_content=False)
     if response:
-      urlretrieve(response)
+        data = response.read()
+        print("Writing to: " + str(id) + ".tar.gz")
+        with open(str(id) + '.tar.gz', 'wb') as f:
+            f.write(data)

--- a/pnc_cli/swagger_client/configuration.py
+++ b/pnc_cli/swagger_client/configuration.py
@@ -77,7 +77,7 @@ class Configuration(object):
 
         # SSL/TLS verification
         # Set this to false to skip verifying SSL certificate when calling API from https server.
-        self.verify_ssl = True
+        self.verify_ssl = False
         # Set this to customize the certificate file to verify the peer.
         self.ssl_ca_cert = None
         # client certificate file

--- a/templates/configuration.mustache
+++ b/templates/configuration.mustache
@@ -72,7 +72,7 @@ class Configuration(object):
 
         # SSL/TLS verification
         # Set this to false to skip verifying SSL certificate when calling API from https server.
-        self.verify_ssl = True
+        self.verify_ssl = False
         # Set this to customize the certificate file to verify the peer.
         self.ssl_ca_cert = None
         # client certificate file


### PR DESCRIPTION
The '_preload_content' is set to False so that the REST API doesn't try
to interpret the returned data (which is a binary tar.gz) into a JSON
response.

The TLS is disabled to reduce issues with certs when downloading the tar
from our Gerrit instances.

### Checklist:

* [ ] Have you added a note in the [Changelog](https://github.com/project-ncl/pnc-cli/wiki/Changelog) for your change if user-facing?
* [ ] Have you added unit tests for your change?
